### PR TITLE
fix two dead links on docs

### DIFF
--- a/Deutscher DiscordTel Guide.md
+++ b/Deutscher DiscordTel Guide.md
@@ -2,7 +2,7 @@
 Diese Anleitung soll Neulingen dabei helfen, DiscordTel für einen Server aufzusetzen und einzustellen.
 
 ## 1. Den Bot einladen => Den Channel aussuchen
-Klicke [hier](https://discordapp.com/oauth2/authorize?client_id=224662505157427200&scope=bot&permissions=84997) um den Bot auf den Server einzuladen, dann wähle oder erstelle einen Channel, dem die DiscordTel-Nummer hinzugefügt werden soll.
+Klicke [hier](https://discordapp.com/oauth2/authorize?client_id=377609965554237453&scope=bot&permissions=84997) um den Bot auf den Server einzuladen, dann wähle oder erstelle einen Channel, dem die DiscordTel-Nummer hinzugefügt werden soll.
 
 ## 2. Eine Nummer auswählen
 Die allgemeine aktuelle Vorwahl ist `0301` für eine Channelnummer oder `0900` für eine Mobilnummer. Bevor du weitermachst, suche dir eine Nummer aus.

--- a/DiscordTel Guide.md
+++ b/DiscordTel Guide.md
@@ -2,7 +2,7 @@
 This guide will assist newcomers in setting up DTel for their server!
 
 ## 1. Inviting the bot => Choosing its channel
-Click [here](https://discordapp.com/oauth2/authorize?client_id=224662505157427200&scope=bot&permissions=84997) to add the bot to your server, then choose/create a channel to register your number in.
+Click [here](https://discordapp.com/oauth2/authorize?client_id=377609965554237453&scope=bot&permissions=84997) to add the bot to your server, then choose/create a channel to register your number in.
 
 ## 2. Choosing a number
 The current normal prefix is `0301` for a channel number or `0900` for a mobile number. Before proceeding, please decide your preferred number.

--- a/Guida in Italiano al DiscordTel.md
+++ b/Guida in Italiano al DiscordTel.md
@@ -2,7 +2,7 @@
 Questa guida assisterà le persone ad installare DiscordTel nel proprio server Discord.
 
 ## 1. Invita il bot => scegli il canale
-Cliccate [qui](https://discordapp.com/oauth2/authorize?client_id=224662505157427200&scope=bot&permissions=84997) per aggiungere il bot al proprio server, poi scegli o crea un canale dedicato alla funzionalità DiscordTel.
+Cliccate [qui](https://discordapp.com/oauth2/authorize?client_id=377609965554237453&scope=bot&permissions=84997) per aggiungere il bot al proprio server, poi scegli o crea un canale dedicato alla funzionalità DiscordTel.
 
 ## 2. Scegliere un numero
 Tutti i numeri normali hanno un prefisso di `0301` per un numero di canale, mentre `0900` per i numeri in messaggio diretto.  

--- a/Guide de DiscordTel en Français.md
+++ b/Guide de DiscordTel en Français.md
@@ -2,7 +2,7 @@
 Ce guide aidera les nouveaux arrivants à configurer DiscordTel pour leur serveur!
 
 ## 1. Inviter le bot => Choisir ses chaîne
-Cliquez [ici](https://discordapp.com/oauth2/authorize?client_id=224662505157427200&scope=bot&permissions=84997) Ajouter le bot À votre serveur, Ensuite, choisissez / créez une chaîne pour registrer votre numéro.
+Cliquez [ici](https://discordapp.com/oauth2/authorize?client_id=377609965554237453&scope=bot&permissions=84997) Ajouter le bot À votre serveur, Ensuite, choisissez / créez une chaîne pour registrer votre numéro.
 
 ## 2. Choisir un numéro
 Le préfixe normal actuel est `0301` pour un numéro de canal ou `0900` pour un numéro de mobile. Avant de procéder, Décidez de votre numéro préféré.

--- a/La guía en español de DiscordTel.md
+++ b/La guía en español de DiscordTel.md
@@ -2,7 +2,7 @@
 Esta guía le ayudará los recién llegados en la creación Dtel para su servidor!
 
 ## 1. Invitando al bot => Elegir su canal
-Hacer clic [aquí](https://discordapp.com/oauth2/authorize?client_id=224662505157427200&scope=bot&permissions=84997) para agregar el bot a su 
+Hacer clic [aquí](https://discordapp.com/oauth2/authorize?client_id=377609965554237453&scope=bot&permissions=84997) para agregar el bot a su 
 servidor, entonces escoge/crear un canal para registro su número.
 
 ## 2. Elegir un número

--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ Welcome to DiscordTel's documentation! Use the navigation bar on the left side o
 
 Enjoy the bot? Help us out by clicking [here](https://discordbots.org/bot/377609965554237453) to give us an upvote! We would greatly appreciate it!
 
-**How do I set up DiscordTel for my own server?** Click [here](http://discordtel.readthedocs.io/en/readthedocs/DiscordTel%20Guide/) to get started!
+**How do I set up DiscordTel for my own server?** Click [here](http://discordtel.readthedocs.io/en/latest/DiscordTel%20Guide/) to get started!
 
 ## Start-up Guide in multiple languages
 * [En Français](http://discordtel.readthedocs.io/en/latest/Guide%20de%20DiscordTel%20en%20Fran%C3%A7ais/)

--- a/简体中文版DiscordTel指南.md
+++ b/简体中文版DiscordTel指南.md
@@ -2,7 +2,7 @@
 本指南将引导初心者在服务器上设置DiscordTel！
 
 ## 1. 邀请机器人并选择频道
-点[此](https://discordapp.com/oauth2/authorize?client_id=224662505157427200&scope=bot&permissions=84997)邀请机器人，之后选择或创建一个频道用来使用您的DTel号码。
+点[此](https://discordapp.com/oauth2/authorize?client_id=377609965554237453&scope=bot&permissions=84997)邀请机器人，之后选择或创建一个频道用来使用您的DTel号码。
 
 ## 2. 选择一个号码
 目前，服务器频道号码的前缀为`0301`，私聊号码的前缀为`0900`。号码为11位，如`0301XXXXXXX`。拨打（`>dial`）时可使用字母代替数字，所以如果您需要在号码中包括字母（如`0301-LETTERS`），请使用[这个工具](http://word2number.com/)。


### PR DESCRIPTION
commit 2ade138 changes the second "readthedocs" to "latest" on line 11 which fixes the link.
the other commits change "?client_id=224662505157427200" to "?client_id=377609965554237453" which fixes the link.